### PR TITLE
Added options to export as array of key-value pairs

### DIFF
--- a/src/entrypoints/FieldExtension.tsx
+++ b/src/entrypoints/FieldExtension.tsx
@@ -35,13 +35,21 @@ export default function FieldExtension({ ctx }: Props) {
     }
   })
 
+  function objectToOutputArray(obj: { [key: string]: string }) {
+    return Object.keys(obj).map((key) => ({ key: key, value: obj[key] }))
+  }
+
   function handleUpdateField(updatedValueList: any[]) {
     const updatedValueObj = arrayToObj(updatedValueList)
     delete updatedValueObj['']
     const updatedFieldPath = JSON.stringify(updatedValueObj)
 
     if (JSON.stringify(parsedFieldValue) !== JSON.stringify(updatedValueObj)) {
-      ctx.setFieldValue(ctx.fieldPath, updatedFieldPath)
+      const newFieldPath = pluginParameters?.exportAsArray
+        ? JSON.stringify(objectToOutputArray(updatedValueObj))
+        : updatedFieldPath
+
+      ctx.setFieldValue(ctx.fieldPath, newFieldPath)
     }
   }
 

--- a/src/entrypoints/FieldExtensionConfigScreen.tsx
+++ b/src/entrypoints/FieldExtensionConfigScreen.tsx
@@ -11,6 +11,13 @@ export default function FieldExtensionConfigScreen({ ctx }: Props) {
   const [addItemValue, setAddItemValue] = useState<boolean>(
     Boolean(pluginParameters?.addItem),
   )
+
+  const [exportAsArrayValue, setExportAsArrayValue] = useState<boolean>(
+    pluginParameters?.exportAsArray
+      ? Boolean(pluginParameters?.exportAsArray)
+      : false,
+  )
+
   const [requiredItemsValue, setRequiredItemsValue] = useState<string>(
     pluginParameters?.requiredFields
       ? String(pluginParameters?.requiredFields)
@@ -20,6 +27,11 @@ export default function FieldExtensionConfigScreen({ ctx }: Props) {
   function handleAddItemChange(newValue: boolean) {
     setAddItemValue(newValue)
     ctx.setParameters({ ...pluginParameters, addItem: newValue })
+  }
+
+  function handleExportAsArray(newValue: boolean) {
+    setExportAsArrayValue(newValue)
+    ctx.setParameters({ ...pluginParameters, exportAsArray: newValue })
   }
 
   function handleRequiredItemsChange(newValue: string) {
@@ -36,6 +48,14 @@ export default function FieldExtensionConfigScreen({ ctx }: Props) {
           label="User may add item"
           value={addItemValue}
           onChange={handleAddItemChange}
+        />
+
+        <SwitchField
+          id="exportAsArray"
+          name="exportAsArray"
+          label="Export values as an array of key-value pairs"
+          value={exportAsArrayValue}
+          onChange={handleExportAsArray}
         />
 
         <TextField


### PR DESCRIPTION
Problem: 
We have been using the JSON table for a while now but started to notice that the values being returned where not maintaining the order that we specified in the table. This is due to the output being structured as an unordered JSON object. 

Solution: 
In order to maintain the order, i am proposing that we add an optional toggle for converting the output format into an array of key-value pairs.